### PR TITLE
Fix broken link to Party sample model

### DIFF
--- a/apps/docs/autogen/tutorial1.md
+++ b/apps/docs/autogen/tutorial1.md
@@ -1,6 +1,6 @@
 # {{title}}
 
-If you read the [Sample Model: Party](tutorial-0) section, you got a brief
+If you read the [Sample Model: Party](sample) section, you got a brief
 introduction to what it's like to explore a NetLogo model. This section will go
 into more depth about the features that are available while you're exploring the
 models in the Models Library.


### PR DESCRIPTION
The link to the Party sample model on the Tutorial 1 page was pointing to a link that's valid for the learn pages, but not for the docs. It now points to the correct link for the docs.